### PR TITLE
BottomNavbar z값 수정

### DIFF
--- a/coffect/src/components/shareComponents/BottomNavbar.tsx
+++ b/coffect/src/components/shareComponents/BottomNavbar.tsx
@@ -47,7 +47,7 @@ export default function BottomNavbar({ activeLabel }: BottomNavbarProps) {
   ];
 
   return (
-    <div className="fixed bottom-4 left-1/2 z-50 flex h-[64px] w-[276px] -translate-x-1/2 items-center justify-around rounded-full bg-[var(--gray-70)] px-6">
+    <div className="fixed bottom-4 left-1/2 z-49 flex h-[64px] w-[276px] -translate-x-1/2 items-center justify-around rounded-full bg-[var(--gray-70)] px-6">
       {tabs.map((tab) => {
         const isActive = activeLabel === tab.label;
         return (


### PR DESCRIPTION
## 📌 BottomNavbar z값 수정

## 🧩 변경 사항

- BottomNavbar z값을 50에서 49로 수정 ( 이를통해 모달들의 기본 z-50인 점을 고려하여 Modal들이 bottomnavbar에 묻히지 않게 함)

## ✅ 체크리스트

- [ ] 코드 스타일을 지켰나요?
- [ ] 테스트를 실행했나요?
- [ ] 리뷰어가 이해하기 쉽게 주석을 썼나요?

## 💬 기타 참고사항

- 관련 문서, 링크 등

