### PR TITLE
[ Chore ] 프로젝트 세팅: 절대 경로 추가

### DIFF
--- a/coffect/src/App.tsx
+++ b/coffect/src/App.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
-import RootLayout from "./components/layout/RootLayout";
+import RootLayout from "@/components/layout/RootLayout";
 import Home from "./pages/Home";
 import Login from "./pages/Login";
 import Signup from "./pages/Signup";

--- a/coffect/src/pages/Community.tsx
+++ b/coffect/src/pages/Community.tsx
@@ -6,13 +6,13 @@ description : 커뮤니티 페이지에 대한 컴포넌트입니다.
 
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import Header from "../components/communityComponents/Header";
-import FeedList from "../components/communityComponents/feed/FeedList";
-import FilterModal from "../components/communityComponents/BottomSeat/FilterModal";
-import BottomNavbar from "../components/shareComponents/BottomNavbar";
-import { type Post, generateDummyPosts } from "../data/communityDummyData";
-import FloatingWriteButton from "../components/communityComponents/FloatingWriteButton";
-import UploadSuccessModal from "../components/communityComponents/writeComponents/UploadSuccessModal";
+import Header from "@/components/communityComponents/Header";
+import FeedList from "@/components/communityComponents/feed/FeedList";
+import FilterModal from "@/components/communityComponents/BottomSeat/FilterModal";
+import BottomNavbar from "@/components/shareComponents/BottomNavbar";
+import { type Post, generateDummyPosts } from "@/data/communityDummyData";
+import FloatingWriteButton from "@/components/communityComponents/FloatingWriteButton";
+import UploadSuccessModal from "@/components/communityComponents/writeComponents/UploadSuccessModal";
 
 // 필터 타입 정의
 interface Filters {

--- a/coffect/tsconfig.app.json
+++ b/coffect/tsconfig.app.json
@@ -21,7 +21,11 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/coffect/vite.config.ts
+++ b/coffect/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import tailwindcss from "@tailwindcss/vite";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), tsconfigPaths()],
   build: {
     outDir: "dist",
   },


### PR DESCRIPTION
### 💡 To Reviewers
- 해당 브랜치에서 새롭게 설치한 라이브러리가 있다면 함께 명시해 주세요.

vite.config.ts에 vite-tsconfig-paths 플러그인을 추가하기 위해서 
npm install --save-dev vite-tsconfig-paths  (  `vite-tsconfig-paths` 패키지를 개발 의존성으로 설치 )
패키지를 추가하였습니다. 

- 리뷰어가 코드를 이해하는 데 도움이 되는 정보나 참고사항이 있다면 자유롭게 작성해 주세요.
사용 예시
만약 src/components/shareComponents/post/FeedItem.tsx 파일에서 유틸리티 함수를 가져온다고 가정해봅시다.

Before (상대 경로):
   1 // 현재 위치에서 상위 폴더로 여러 번 이동해야 함
   2 import { formatDate } from '../../../utils/dateUtils';

  경로가 복잡하고, 이 파일의 위치가 바뀌면 경로도 수정해야 합니다.

After (절대 경로):
   1 // 프로젝트 src 폴더 기준으로 경로 작성
   2 import { formatDate } from '@/utils/dateUtils';

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
1. tsconfig.app.json 파일을 수정하여 절대 경로를 설정
2. vite.config.ts에 vite-tsconfig-paths 플러그인을 추가
     2-1. 관련 패키지를 설치 => npm install --save-dev vite-tsconfig-paths 
     2-2. 2. vite.config.ts 파일을 수정하여 플러그인을 추가
3. App.tsx 와 pages/Community.tsx 에 예시로 경로 수정

=================================================================

같은 디렉토리 내의 파일을 임포트할 때는 상대 경로(import MyUtil from './MyUtil')를 사용하
다른 디렉토리의 파일을 임포트할 때는 절대 경로(import MyComponent from '@/components/MyComponent')를 사용하는 등 
명확한 기준을 정하면 좋을 것 같습니다.

### 🤔 추후 작업 예정
- 각 개발자는 절대 경로로 경로를 수정해주세요 !

### 📸 작업 결과 (스크린샷)
- 작업 결과를 보여주는 스크린샷을 첨부해 주세요.
<img width="1033" height="224" alt="image" src="https://github.com/user-attachments/assets/40601c2c-16ef-4e54-b821-810c2eb6cfe3" />


### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- #37 
