### PR TITLE
[Fix] CommentInput 에서 스크롤이 생기는 문제 수정

### DIFF
--- a/coffect/src/components/communityComponents/comment/CommentInput.tsx
+++ b/coffect/src/components/communityComponents/comment/CommentInput.tsx
@@ -32,14 +32,14 @@ const CommentInput = ({ postId }: CommentInputProps) => {
         <textarea
           ref={textareaRef}
           placeholder="댓글을 남겨보세요."
-          className="scrollbar-hide max-h-24 w-full resize-none rounded-2xl border border-gray-300 bg-[#f5f5f5] py-3 pr-14 pl-5 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+          className="scrollbar-hide max-h-24 w-full resize-none overflow-hidden rounded-2xl bg-[var(--gray-5)] py-3 pr-17 pl-5 focus:ring-2 focus:ring-blue-500 focus:outline-none"
           value={newComment}
           onChange={(e) => setNewComment(e.target.value)}
           rows={1}
         />
         {newComment.trim() && (
           <button
-            className="absolute top-1/2 right-2 -translate-y-1/2 rounded-full bg-[#FF8126] px-4.5 py-1.5 text-white hover:bg-[#e0701f] disabled:bg-gray-300"
+            className="absolute top-1/2 right-2 -translate-y-1/2 rounded-full bg-[var(--design-text)] px-4.5 py-1.5 text-white disabled:bg-gray-300"
             onClick={handlePostComment}
           >
             <Send className="h-5 w-5" />


### PR DESCRIPTION
### 💡 To Reviewers
- 해당 브랜치에서 새롭게 설치한 라이브러리가 있다면 함께 명시해 주세요.
없습니다.
- 리뷰어가 코드를 이해하는 데 도움이 되는 정보나 참고사항이 있다면 자유롭게 작성해 주세요.
textarea에 overflow-hidden 클래스를 추가하여 스크롤바가 아예 생기지 않도록 수정했습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- CommentInput.tsx의 textarea에 overflow-hidden 클래스를 추가하여 스크롤바가 아예 생기지 않도록 수정했습니다.
<img width="808" height="186" alt="image" src="https://github.com/user-attachments/assets/2e125516-aa7b-4b81-ace5-e2d58a6573f6" />


### 🤔 추후 작업 예정
- 게시글 불러오기 API 연동 작업을 진행할 예정입니다.

### 📸 작업 결과 (스크린샷)
- 
<img width="388" height="270" alt="image" src="https://github.com/user-attachments/assets/e4fea82b-4569-4679-a6f6-59304516c2eb" />


### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- closed #61 
