### PR TITLE
[Feat] 학교 도메인 검증 API 설정 및 연결 

### DIFF
--- a/coffect/src/api/univ.ts
+++ b/coffect/src/api/univ.ts
@@ -30,7 +30,7 @@ export const sendMailCode = async (email: string, univName: string) => {
     });
     return response.data;
   } catch (error) {
-    console.error('Failed to send mail code:', error);
+    console.error("Failed to send mail code:", error);
     throw error;
   }
 };
@@ -43,7 +43,7 @@ export const verifyEmailCode = async (email: string, certCode: number) => {
     });
     return res.data;
   } catch (error) {
-    console.error('Failed to verify email code:', error);
+    console.error("Failed to verify email code:", error);
     throw error;
   }
 };
@@ -89,4 +89,21 @@ export const signUpRequest = async ({
   });
 
   return response.data;
+};
+
+// 특정 이메일의 대학교 도메인 유효성 검증
+export const checkUnivDomain = async (email: string) => {
+  try {
+    const res = await axiosInstance.post(
+      "/univ/domain",
+      { email },
+      {
+        headers: { "X-Skip-Auth-Redirect": "true" }, // 이 요청만 401 리다이렉트 예외
+      },
+    );
+    return res.data;
+  } catch (error) {
+    console.error("Failed to check university domain:", error);
+    throw error;
+  }
 };

--- a/coffect/src/utils/validation.ts
+++ b/coffect/src/utils/validation.ts
@@ -1,21 +1,4 @@
 /*
-  이메일 포맷 검사 + 도메인 검사
-  @ 앞 부분: 영문 대소문자, 숫자, 언더바(_), 점(.)만 허용, 1자 이상
-  @ 뒤 부분: 공백과 @ 제외한 1자 이상, 마지막 . 뒤에도 1자 이상
-  도메인 ac.kr, edu.kr, .edu 포함만 가능
-*/
-export const isValidSchoolEmail = (email: string): boolean => {
-  // 기본 이메일 형식 검사
-  const emailRegex = /^[A-Za-z0-9_.]+@[^\s@]+\.[^\s@]+$/;
-  if (!emailRegex.test(email)) return false;
-
-  // 학교 이메일 도메인 검사
-  const domain = email.split("@")[1];
-  const domainRegex = /(ac\.kr|edu(\.kr)?|\.edu)$/i;
-  return domainRegex.test(domain);
-};
-
-/*
   비밀번호 포맷 검사
   영문/숫자/특수문자를 모두 포함하며 최소 8자 이상이어야 함
 */


### PR DESCRIPTION
### 💡 To Reviewers
- 해당 브랜치에서 새롭게 설치한 라이브러리가 있다면 함께 명시해 주세요.
- 리뷰어가 코드를 이해하는 데 도움이 되는 정보나 참고사항이 있다면 자유롭게 작성해 주세요.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
/univ/domain API 설정 및 호출
axiosInstance에 예외 헤더 추가 (401 리다이렉트 방지)
EmailVerification에서 API 연결 완료
기존 util 함수 제거
(.edu, ac.kr 외 .kr로 끝나는 학교 존재하나, 일반 .kr 도메인 많아 API로만 처리)

### 🤔 추후 작업 예정
- 추가 구현이 필요한 부분이나 다음 작업 계획을 작성해 주세요.

### 📸 작업 결과 (스크린샷)
- 작업 결과를 보여주는 스크린샷을 첨부해 주세요.

### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: closed #138 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 회원가입 이메일 인증 시 서버 기반 대학 도메인 검증을 추가하여 학교 이메일 여부를 정확히 확인합니다.
  - 검증 실패 사유를 토스트로 안내하고, 인증 요청을 중단합니다.
- 버그 수정
  - 인증 과정에서 발생하는 오류 상황(401 포함)에 대한 안내 메시지를 개선해 혼선을 줄였습니다.
- 리팩터링
  - 기존의 클라이언트 단 이메일 도메인 검사를 제거하고 비동기 서버 검증 흐름으로 전환했습니다.
  - 이메일 인증 버튼 동작을 새로운 검증 절차에 맞게 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->