### PR TITLE
[Feat] 댓글에 학과 추가 및 클릭 시 상대 페이지 넘어감 구현 

### DIFF
--- a/coffect/src/components/communityComponents/comment/CommentItem.tsx
+++ b/coffect/src/components/communityComponents/comment/CommentItem.tsx
@@ -8,6 +8,7 @@
  *          (nickname -> name, content -> commentBody, major 제거)
  */
 import type { Comment } from "@/types/community/commentTypes";
+import { useNavigate } from "react-router-dom";
 // import { formatTimeAgo } from "@/utils/dateUtils";
 
 /**
@@ -20,10 +21,18 @@ interface CommentItemProps {
 }
 
 const CommentItem = ({ comment }: CommentItemProps) => {
+  const navigate = useNavigate();
+  const handleCommentClick = () => {
+    navigate(`/userpage/${comment.user.id}`);
+  };
+
   return (
-    <div className="flex items-start gap-3 py-2.25">
+    <div
+      className="flex items-start gap-3 py-2.25"
+      onClick={handleCommentClick}
+    >
       <img
-        src={comment.user.profileImage || "https://via.placeholder.com/40"} // 임시 기본 이미지,,
+        src={comment.user.profileImage || "https://via.placeholder.com/40"}
         alt={comment.user.name}
         className="h-10 w-10 rounded-full object-cover"
       />
@@ -32,10 +41,14 @@ const CommentItem = ({ comment }: CommentItemProps) => {
           <span className="font-semibold text-[var(--gray-90)]">
             {comment.user.name}
           </span>
-          <span className="text-sm text-[var(--gray-40)]">
-            {/* API 응답에 major가 없으므로 학번만 표시 => major 추가 시 major로 변경 !*/}
-            {String(comment.user.studentId).substring(2, 4)}학번
-          </span>
+          <div>
+            <span className="pr-1 text-sm text-[var(--gray-40)]">
+              {comment.user.dept}
+            </span>
+            <span className="text-sm text-[var(--gray-40)]">
+              {String(comment.user.studentId).substring(2, 4)}학번
+            </span>
+          </div>
         </div>
         <p className="font-md break-words whitespace-pre-wrap text-[var(--gray-90)]">
           {comment.commentBody}

--- a/coffect/src/components/shareComponents/FeedItem.tsx
+++ b/coffect/src/components/shareComponents/FeedItem.tsx
@@ -28,7 +28,6 @@ const FeedItem = ({
   // 작성자 클릭 시 해당 작성자의 프로필 페이지로 이동하는 함수입니다
   const handleAuthorClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    console.log(`navigating to user page: /userpage/${post.user.id}`);
     navigate(`/userpage/${post.user.id}`);
   };
 

--- a/coffect/src/components/shareComponents/LoadingScreen.tsx
+++ b/coffect/src/components/shareComponents/LoadingScreen.tsx
@@ -1,6 +1,6 @@
 export default function LoadingScreen() {
   return (
-    <div className="w-ful flex h-full flex-col items-center justify-center bg-white">
+    <div className="flex h-full w-full flex-col items-center justify-center bg-white">
       {/* 메인 텍스트 */}
       <p className="w-[177px] text-[22px] font-semibold text-[var(--gray-90)]">
         잠시만 기다려주세요

--- a/coffect/src/pages/PostDetailPage.tsx
+++ b/coffect/src/pages/PostDetailPage.tsx
@@ -19,6 +19,7 @@ import PostDetailHeader from "@/components/postDetailComponents/PostDetailHeader
 import CommentInput from "@/components/communityComponents/comment/CommentInput";
 import { useGetComments } from "@/hooks/community/query/useGetComments";
 import PostDetailComments from "@/components/postDetailComponents/PostDetailComments";
+import LoadingScreen from "@/components/shareComponents/LoadingScreen";
 
 const PostDetail = () => {
   // 1. 게시글 상세 정보 로딩: usePostDetail 훅을 호출합니다.
@@ -42,11 +43,7 @@ const PostDetail = () => {
 
   // 데이터 로딩 중일 때 표시할 UI (게시글 또는 댓글 중 하나라도 로딩 중일 때)
   if (isPostLoading || isCommentsLoading) {
-    return (
-      <div className="flex h-screen items-center justify-center bg-white">
-        게시글을 불러오는 중입니다...
-      </div>
-    );
+    return <LoadingScreen />;
   }
 
   // 에러 발생 시 표시할 UI (게시글 또는 댓글 에러 중 하나라도 발생했을 때)

--- a/coffect/src/types/community/commentTypes.ts
+++ b/coffect/src/types/community/commentTypes.ts
@@ -20,6 +20,8 @@ export interface Comment {
     studentId: number; // 학생 ID
     profileImage: string; // 프로필 이미지 URL
     name: string; // 작성자 이름
+    dept: string; // 학과
+    id: string; // 작성자 페이지로 가기 위함.
   };
 }
 


### PR DESCRIPTION
### 💡 To Reviewers
- 해당 브랜치에서 새롭게 설치한 라이브러리가 있다면 함께 명시해 주세요.
없습니다.
- 리뷰어가 코드를 이해하는 데 도움이 되는 정보나 참고사항이 있다면 자유롭게 작성해 주세요.
Api 에서 user.dept 를 추가하여 comment api에서도 학과를 추가할 수 있습니다.
Api 에서 user.id 를 추가하여 comment 에서도 상대 페이지로 넘어갈 수 있습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- API 수정
- 댓글에 학과 UI 구현 및 클릭 시 상대 페이지로 이동 구현

### 🤔 추후 작업 예정
- 추가 구현이 필요한 부분이나 다음 작업 계획을 작성해 주세요.
CommentInput에서 불러오는 API를 comment에서 post로 바꿔야할 것 같습니다.
현재 상대 게시물에 댓글을 달고자할 때 CommentInput에 프로필 이미지가 상대 이미지로 뜨는 오류 발생함.

### 📸 작업 결과 (스크린샷)
- 작업 결과를 보여주는 스크린샷을 첨부해 주세요.

### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: closed #2
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 댓글 아이템 전체 클릭 시 작성자 프로필로 이동합니다.
  - 게시글 상세의 로딩 상태가 통합된 로딩 화면으로 표시됩니다.
- 스타일
  - 댓글의 사용자 표기를 학과 우선, 이어서 학번(연도 추출)으로 재구성했습니다.
  - 로딩 화면 레이아웃 클래스 오타(w-ful → w-full) 수정으로 표시 안정성 향상.
- 잡무
  - 불필요한 디버그 로그 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->