### PR TITLE
[ Fix ] 댓글 작성에 프로필 이미지 내 이미지로 뜨도록 수정

### DIFF
--- a/coffect/src/components/communityComponents/comment/CommentInput.tsx
+++ b/coffect/src/components/communityComponents/comment/CommentInput.tsx
@@ -13,19 +13,21 @@ import { useState, useRef } from "react";
 import { useAddComment } from "@/hooks/community/mutation/useAddComment";
 import { Send } from "lucide-react";
 import useAutoResizeTextarea from "@/hooks/useAutoResizeTextarea";
-import { usePostDetail } from "@/hooks/community/query/usePostDetail";
 
 interface CommentInputProps {
   postId?: string;
+  currentUserProfileImage?: string;
 }
 
-const CommentInput = ({ postId }: CommentInputProps) => {
+const CommentInput = ({
+  postId,
+  currentUserProfileImage,
+}: CommentInputProps) => {
   const [commentBody, setCommentBody] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   useAutoResizeTextarea(textareaRef.current, commentBody);
 
   const { mutate: addComment, isPending } = useAddComment();
-  const { post } = usePostDetail();
 
   const handlePostComment = () => {
     if (!postId || commentBody.trim() === "" || isPending) return;
@@ -53,7 +55,7 @@ const CommentInput = ({ postId }: CommentInputProps) => {
   return (
     <div className="flex w-full flex-shrink-0 items-center gap-3 bg-white">
       <img
-        src={post?.user.profileImage}
+        src={currentUserProfileImage}
         alt="CurrentUser"
         className="h-10 w-10 rounded-full"
       />
@@ -65,7 +67,7 @@ const CommentInput = ({ postId }: CommentInputProps) => {
           value={commentBody}
           onChange={(e) => setCommentBody(e.target.value)}
           rows={1}
-          disabled={isPending} // 댓글 전송 중에는 입력 비활성화
+          disabled={isPending}
         />
         {commentBody.trim() && (
           <button

--- a/coffect/src/pages/PostDetailPage.tsx
+++ b/coffect/src/pages/PostDetailPage.tsx
@@ -20,9 +20,11 @@ import CommentInput from "@/components/communityComponents/comment/CommentInput"
 import { useGetComments } from "@/hooks/community/query/useGetComments";
 import PostDetailComments from "@/components/postDetailComponents/PostDetailComments";
 import LoadingScreen from "@/components/shareComponents/LoadingScreen";
+import { useQuery } from "@tanstack/react-query";
+import { getProfile } from "@/api/profile";
+import type { profileType } from "@/types/mypage/profile";
 
 const PostDetail = () => {
-  // 1. 게시글 상세 정보 로딩: usePostDetail 훅을 호출합니다.
   const {
     post,
     postId: postId,
@@ -31,17 +33,17 @@ const PostDetail = () => {
     error: postError,
   } = usePostDetail();
 
-  console.log("댓글 조회를 위해 전달하는 postId:", postId);
-
   const {
     comments,
-    postId: commentPostId,
     isLoading: isCommentsLoading,
     error: commentsError,
   } = useGetComments();
-  console.log("댓글 조회를 위해 전달하는 postId:", commentPostId);
 
-  // 데이터 로딩 중일 때 표시할 UI (게시글 또는 댓글 중 하나라도 로딩 중일 때)
+  const { data: myProfile } = useQuery<profileType>({
+    queryKey: ["myProfile"],
+    queryFn: getProfile,
+  });
+
   if (isPostLoading || isCommentsLoading) {
     return <LoadingScreen />;
   }
@@ -93,7 +95,10 @@ const PostDetail = () => {
       </main>
 
       <div className="fixed bottom-0 left-1/2 w-full max-w-[430px] -translate-x-1/2 border-t border-gray-200 bg-white p-3 pb-4">
-        <CommentInput postId={postId} />
+        <CommentInput
+          postId={postId}
+          currentUserProfileImage={myProfile?.success?.userInfo.profileImage}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
### 💡 To Reviewers
- 해당 브랜치에서 새롭게 설치한 라이브러리가 있다면 함께 명시해 주세요.
프로필에 게시물 작성자의 프로필이 뜨는 문제 해결

- 리뷰어가 코드를 이해하는 데 도움이 되는 정보나 참고사항이 있다면 자유롭게 작성해 주세요.
/profile 에서 사용하는 query를 가져와서 해결했습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- PostDetailPage에서 queryKey [myprofile] 을 부름
- PostDetailPage에서 CommetInput으로 프로필 넘김.
- CommentInput에서 해당 프로필 띄움 !

### 🤔 추후 작업 예정
- 추가 구현이 필요한 부분이나 다음 작업 계획을 작성해 주세요.
- 유지보수 및 버그 발견 시 수정

### 📸 작업 결과 (스크린샷)
- 작업 결과를 보여주는 스크린샷을 첨부해 주세요.
<img width="398" height="812" alt="image" src="https://github.com/user-attachments/assets/70e75bcc-70ba-4f74-b34b-157f2365099a" />

### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 게시글 상세의 댓글 입력창에 현재 사용자 프로필 이미지가 표시됩니다.
  - 댓글 전송 중일 때 전송 버튼이 "..."로 바뀌어 진행 상태를 명확히 보여줍니다.
- Refactor
  - 댓글 입력 영역이 불필요한 데이터 의존성을 줄여 더 일관된 표시와 약간 개선된 초기 반응성을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->