### PR TITLE
[Fix/design] 초기화 버튼 클릭 시 주제/종류 기본 선택 및 빈 배열 받을 시 게시글 없음 UI 표시

### DIFF
--- a/coffect/src/components/communityComponents/ChipFilterComponent/filterData.ts
+++ b/coffect/src/components/communityComponents/ChipFilterComponent/filterData.ts
@@ -18,9 +18,9 @@ export const postTypeOptions: ChipOption[] = [
   { id: 1, value: "아티클", label: "아티클 ✍🏻" },
   { id: 2, value: "팀원모집", label: "팀원 모집 👬" },
   { id: 3, value: "질문", label: "질문 👤" },
-  { id: 4, value: "도움필요", label: "도움 필요 🤩" },
+  { id: 4, value: "도움_필요", label: "도움 필요 🤩" },
   { id: 5, value: "후기글", label: "후기글 ☕" },
-  { id: 6, value: "팁공유", label: "팁 공유 📌" },
+  { id: 6, value: "팁_공유", label: "팁 공유 📌" },
 ];
 
 /**

--- a/coffect/src/pages/Community.tsx
+++ b/coffect/src/pages/Community.tsx
@@ -120,7 +120,7 @@ const Community = () => {
       <main className="flex-1 overflow-y-auto bg-white pb-20">
         {isLoading ? (
           <FeedListSkeleton />
-        ) : (
+        ) : posts.length > 0 ? (
           <>
             <FeedList posts={posts} />
             <div ref={ref} style={{ height: "1px" }} />
@@ -130,6 +130,11 @@ const Community = () => {
               </div>
             )}
           </>
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center text-center text-gray-500">
+            <p className="text-lg font-bold">아직 게시글이 없어요!</p>
+            <p className="mt-2 text-sm">다른 필터 조건을 선택해 보세요.</p>
+          </div>
         )}
       </main>
 

--- a/coffect/src/store/community/communityStore.ts
+++ b/coffect/src/store/community/communityStore.ts
@@ -36,7 +36,7 @@ export const useCommunityStore = create<CommunityState & CommunityActions>(
       set((state) => ({
         filters: { ...state.filters, ...newFilters },
       })),
-    resetFilters: () => set({ filters: { type: null, subject: null } }),
+    resetFilters: () => set({ filters: { type: "아티클", subject: [1] } }),
     openFilterModal: () => set({ isFilterModalOpen: true }),
     closeFilterModal: () => set({ isFilterModalOpen: false }),
   }),


### PR DESCRIPTION
## 📌 PR 제목

- 초기화 버튼 클릭 시 주제/종류 선택 X -> 초기 선택으로 수정
- 선택한 필터의 게시글이 없을 경우 게시글 없음 UI 구현

## 🧩 변경 사항

- 필터 전역상태에서 초기화 버튼 클릭 시 type, subject 값 수정

## ✅ 체크리스트

[ ] 코드 스타일을 지켰나요?
[ ] 테스트를 실행했나요?
[ ] 리뷰어가 이해하기 쉽게 주석을 썼나요?

## 💬 기타 참고사항

- 관련 문서, 링크 등

