### PR TITLE
[Fix] 채팅방 내부 모달 수정

### DIFF
--- a/coffect/src/api/chat/socketInstance.ts
+++ b/coffect/src/api/chat/socketInstance.ts
@@ -121,7 +121,6 @@ class SocketManager {
   // 메시지 수신 리스너
   onReceiveMessage(callback: (message: SocketMessage) => void) {
     if (!this.socket) return;
-
     this.socket.on(SOCKET_EVENTS.RECEIVE_MESSAGE, callback);
   }
 

--- a/coffect/src/components/chat/ChatInputBox.tsx
+++ b/coffect/src/components/chat/ChatInputBox.tsx
@@ -3,7 +3,7 @@
  * description : 채팅방 내부 입력창
  */
 
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import { Plus, Send, X as XIcon } from "lucide-react";
 
 interface ChatInputBoxProps {
@@ -28,6 +28,27 @@ const ChatInputBox: React.FC<ChatInputBoxProps> = ({
   const cameraInputRef = useRef<HTMLInputElement>(null);
   const galleryInputRef = useRef<HTMLInputElement>(null);
   const [showImageOptions, setShowImageOptions] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // 외부 클릭 감지
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        modalRef.current &&
+        !modalRef.current.contains(event.target as Node)
+      ) {
+        setShowImageOptions(false);
+      }
+    };
+
+    if (showImageOptions) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [showImageOptions]);
 
   const trySend = () => {
     if (imageFile) {
@@ -105,6 +126,7 @@ const ChatInputBox: React.FC<ChatInputBoxProps> = ({
             {/* 이미지 업로드 옵션 모달 */}
             {showImageOptions && (
               <div
+                ref={modalRef}
                 className="absolute bottom-11 -left-1 z-50 flex flex-col rounded-xl border border-[var(--gray-5)] bg-white shadow-lg"
                 onClick={(e) => {
                   if (e.target === e.currentTarget) setShowImageOptions(false);

--- a/coffect/src/components/chat/ChatInterestsSection.tsx
+++ b/coffect/src/components/chat/ChatInterestsSection.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useNavigate } from "react-router-dom";
-import { Calendar, Mail, ChevronUp, ChevronDown } from "lucide-react";
+import { Calendar, Mail, ChevronUp } from "lucide-react";
 import ChatInterestTags from "./ChatInterestTags";
 
 interface Schedule {
@@ -129,19 +129,7 @@ const ChatInterestsSection = ({
             </div>
           )}
         </div>
-      ) : (
-        <div className="flex justify-end bg-[var(--gray-5)] px-4 py-3">
-          <button
-            type="button"
-            onClick={onToggleInterests}
-            aria-label="관심사 섹션 펼치기"
-            aria-expanded={false}
-            className="cursor-pointer rounded-full bg-[var(--white)] p-1 text-[var(--gray-50)] shadow-[0_0_12px_0_rgba(0,0,0,0.15)]"
-          >
-            <ChevronDown size={24} aria-hidden="true" />
-          </button>
-        </div>
-      )}
+      ) : null}
     </>
   );
 };

--- a/coffect/src/components/chat/ChatMessageArea.tsx
+++ b/coffect/src/components/chat/ChatMessageArea.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useRef } from "react";
+import { ChevronDown } from "lucide-react";
 import ChatMessageList from "./ChatMessageList";
 import { ChatSystemMessage } from "./ChatSystemMessage";
 import useAutoScroll from "./hooks/useAutoScroll";
@@ -14,20 +15,41 @@ interface ChatMessageAreaProps {
   messages: Message[];
   username?: string;
   opponentProfileImage?: string;
+  showInterests?: boolean;
+  onToggleInterests?: () => void;
 }
 
 const ChatMessageArea = ({
   messages,
   username,
   opponentProfileImage,
+  showInterests,
+  onToggleInterests,
 }: ChatMessageAreaProps) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   useAutoScroll(messagesEndRef, messages);
 
   return (
-    <div className="flex-1 overflow-y-auto bg-[var(--gray-5)] px-4 py-2">
+    <div className="relative flex-1 overflow-y-auto bg-[var(--gray-5)] px-4 py-2">
+      {/* 플로팅 버튼 - 관심사가 닫혀있을 때만 표시 */}
+      {!showInterests && onToggleInterests && (
+        <div className="sticky top-1 z-50 -mr-2 mb-0 flex justify-end">
+          <button
+            type="button"
+            onClick={onToggleInterests}
+            aria-label="관심사 섹션 펼치기"
+            aria-expanded={false}
+            className="cursor-pointer rounded-full bg-[var(--white)] p-1 text-[var(--gray-50)] shadow-[0_4px_12px_0_rgba(0,0,0,0.15)] transition-shadow duration-200 hover:shadow-[0_6px_16px_0_rgba(0,0,0,0.2)]"
+          >
+            <ChevronDown size={24} aria-hidden="true" />
+          </button>
+        </div>
+      )}
+
       {/* 시스템 메시지 */}
-      <ChatSystemMessage username={username || "상대방"} />
+      <div className={showInterests ? "mt-2" : "-mt-6"}>
+        <ChatSystemMessage username={username || "상대방"} />
+      </div>
 
       <ChatMessageList
         messages={messages}

--- a/coffect/src/components/chat/chatRoom.tsx
+++ b/coffect/src/components/chat/chatRoom.tsx
@@ -373,6 +373,8 @@ const ChatRoom = () => {
         messages={messages}
         username={currentChatRoom?.userInfo?.name || "상대방"}
         opponentProfileImage={currentChatRoom?.userInfo?.profileImage}
+        showInterests={showInterests}
+        onToggleInterests={handleToggleInterests}
       />
 
       {/* 입력창 */}


### PR DESCRIPTION
### 💡 To Reviewers

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- 관심 태그 닫는 토글 플로팅 처리, 간격 조정
- 이미지 선택 모달 외부 영역 클릭 시 close 처리

### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- #164


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 메시지 영역에 관심사 패널 토글 버튼(플로팅) 추가: 패널이 숨겨졌을 때 쉽게 열 수 있음.
  - 이미지 옵션 모달이 바깥 영역 클릭 시 자동으로 닫히도록 개선.

- Style
  - 레이아웃 소폭 조정(컨테이너 위치와 상단 마진 최적화)으로 표시 안정성 향상.
  - 하단 확장 컨트롤 제거로 인터페이스 단순화.
  - 비기능적 공백 제거 등 경미한 코드 정리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->