### PR TITLE
[ Feat ] 커뮤니티 처음 접속 시에 모든 게시글 조회 및 필터 시에 필터 조회 기능 구현

### DIFF
--- a/coffect/src/hooks/community/query/useGetThreadLatestQuery.ts
+++ b/coffect/src/hooks/community/query/useGetThreadLatestQuery.ts
@@ -13,18 +13,20 @@ import type { GetThreadLatestResponse } from "@/types/community/postTypes";
  * @constant QUERY_KEY
  * @description react-query가 이 쿼리를 식별하고 캐시를 관리하기 위한 고유 키입니다.
  */
-const QUERY_KEY = ["community", "latestPosts"];
+const QUERY_KEY = ["community", "posts"];
 
 /**
  * @function useGetThreadLatestQuery
  * @description 최신순 게시글 목록 데이터를 무한 스크롤로 가져오는 커스텀 훅
  * @returns useInfiniteQuery의 결과 객체 ({ data, fetchNextPage, hasNextPage, ... })
  */
-export const useGetThreadLatestQuery = ({ enabled }: { enabled?: boolean } = {}) => {
+export const useGetThreadLatestQuery = ({
+  enabled,
+}: { enabled?: boolean } = {}) => {
   return useInfiniteQuery<GetThreadLatestResponse, Error>({
     queryKey: QUERY_KEY,
     queryFn: ({ pageParam }) =>
-      getThreadLatest({ cursor: pageParam as number | undefined }),
+      getThreadLatest({ dateCursor: pageParam as string | undefined }),
     initialPageParam: undefined,
     getNextPageParam: (lastPage) => {
       if (lastPage.success && lastPage.success.nextCursor !== -1) {
@@ -32,6 +34,6 @@ export const useGetThreadLatestQuery = ({ enabled }: { enabled?: boolean } = {})
       }
       return undefined;
     },
-    enabled, // enabled 속성을 직접 전달합니다.
+    enabled,
   });
 };

--- a/coffect/src/store/community/communityStore.ts
+++ b/coffect/src/store/community/communityStore.ts
@@ -25,8 +25,8 @@ export const useCommunityStore = create<CommunityState & CommunityActions>(
     // 초기 상태 값
     sortOrder: "createdAt",
     filters: {
-      type: "아티클",
-      subject: [1],
+      type: "",
+      subject: [],
     },
     isFilterModalOpen: false,
 
@@ -36,7 +36,7 @@ export const useCommunityStore = create<CommunityState & CommunityActions>(
       set((state) => ({
         filters: { ...state.filters, ...newFilters },
       })),
-    resetFilters: () => set({ filters: { type: "아티클", subject: [1] } }),
+    resetFilters: () => set({ filters: { type: "", subject: [] } }),
     openFilterModal: () => set({ isFilterModalOpen: true }),
     closeFilterModal: () => set({ isFilterModalOpen: false }),
   }),

--- a/coffect/src/types/community/postTypes.ts
+++ b/coffect/src/types/community/postTypes.ts
@@ -5,42 +5,6 @@
  *              - 타입 이름은 '기능 + 목적' (예: GetPostsRequest) 또는 '데이터 모델' (예: Post)으로 명명합니다.
  */
 
-// /**
-//  * @interface Post
-//  * @description 단일 게시글의 상세 정보를 나타내는 기본 데이터 모델입니다.
-//  *              API 응답 등 다양한 곳에서 재사용됩니다.
-//  */
-// export interface Post {
-//   resultType: string; // 결과 타입 (예: "success", "error")
-//   error: null | {
-//     errorCode: string; // 에러 코드 (예: "THR-04")
-//     reason: string; // 에러 사유 (예: "게시글 ID가 없습니다.")
-//     data: null; // 추가 데이터 (없을 경우 null)
-//   };
-//   success: null | {
-//     result: {
-//       threadId: string; // 게시글 고유 ID
-//       threadTitle: string; // 게시글 제목
-//       threadBody: string; // 게시글 본문 내용
-//       threadShare: number; // 공유 수 (예: 0)
-//       createdAt: string; // 게시글 작성일 (ISO 8601 형식)
-//       type: string; // 게시글 종류 (예: "아티클", "질문")
-//       user: {
-//         profileImage: string; // 작성자 프로필 이미지 URL
-//         name: string; // 작성자 이름
-//         userId: number; // 작성자 고유 ID
-//       };
-//       subjectMatch: Array<{
-//         threadSubject: {
-//           subjectName: string; // 게시글 주제 이름
-//           subjectId: number; // 게시글 주제 고유 ID
-//         };
-//       }>;
-//     };
-//     likes: number; // 좋아요 수
-//   };
-// }
-
 /**
  * @interface ThreadSummary
  * @description 게시글 목록에 사용되는 각 게시글의 요약 정보 모델입니다.
@@ -95,7 +59,7 @@ export interface ThreadSummary {
 /************************ 최신순 게시글 조회 API ************************/
 
 export interface GetThreadLatestRequest {
-  cursor?: number;
+  dateCursor?: string;
 }
 
 export interface GetThreadLatestResponse {


### PR DESCRIPTION
### 💡 To Reviewers
- 해당 브랜치에서 새롭게 설치한 라이브러리가 있다면 함께 명시해 주세요.
없습니다.

- 리뷰어가 코드를 이해하는 데 도움이 되는 정보나 참고사항이 있다면 자유롭게 작성해 주세요.
Community.tsx에서 useState로 /thread/latest를 호출할 지, /thread/main 으로 필터된 값을 호출할 지 정의했습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- /thread/latest api 호출 구현
- Community에 useState로 상황별 api 호출 구현

### 🤔 추후 작업 예정
- 추가 구현이 필요한 부분이나 다음 작업 계획을 작성해 주세요.
- 내일 아마 글 작성페이지에서 image-crop 할 것 같습니ㅏㄷ.

### 📸 작업 결과 (스크린샷)
- 작업 결과를 보여주는 스크린 샷. -> 초기화 누르면 필터 값 초기화 및 모든 게시글이 뜸.

<img width="628" height="853" alt="스크린샷 2025-08-15 040944" src="https://github.com/user-attachments/assets/ef9119ee-9fcd-4013-8f1d-066d0bbee1a1" />
<img width="584" height="857" alt="스크린샷 2025-08-15 040936" src="https://github.com/user-attachments/assets/ba670505-09c3-4e2d-a58d-308b7a682f31" />

- 
### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: closed #167 
