### PR TITLE
Fix: 채팅방 레이아웃 문제, 이미지 전송 시간 표시 해결

### DIFF
--- a/coffect/src/components/chat/ChatMessageList.tsx
+++ b/coffect/src/components/chat/ChatMessageList.tsx
@@ -57,6 +57,8 @@ const ChatMessageList: React.FC<Props> = ({
                   imageUrl={msg.imageUrl}
                   showProfile={showProfile}
                   profileImage={opponentProfileImage}
+                  time={msg.time}
+                  showTime={shouldShowTime(idx)}
                 />
               ) : (
                 <MessageBubble

--- a/coffect/src/components/chat/ChatRoomList.tsx
+++ b/coffect/src/components/chat/ChatRoomList.tsx
@@ -5,7 +5,6 @@
 
 import React from "react";
 import { useNavigate } from "react-router-dom";
-import { getTimeAgo } from "../../utils/dateUtils";
 import type { ChatRoomWithUser } from "../../types/chat";
 
 interface ChatRoomItemProps {
@@ -20,12 +19,12 @@ const ChatRoomItem: React.FC<ChatRoomItemProps> = ({ chatRoom, onClick }) => {
       onClick={() => onClick(chatRoom)}
     >
       {/* 프로필 */}
-      <div className="relative flex h-13 w-13 items-center justify-center overflow-hidden rounded-full bg-[var(--gray-20)]">
+      <div className="relative flex h-13 w-13 items-center justify-center rounded-full bg-[var(--gray-20)]">
         {chatRoom.userInfo?.profileImage ? (
           <img
             src={chatRoom.userInfo.profileImage}
             alt={`${chatRoom.userInfo.name} 프로필`}
-            className="h-full w-full object-cover"
+            className="h-full w-full rounded-full object-cover"
             onError={(e) => {
               // 이미지 로드 실패 시 기본 배경색 유지
               e.currentTarget.style.display = "none";
@@ -36,8 +35,7 @@ const ChatRoomItem: React.FC<ChatRoomItemProps> = ({ chatRoom, onClick }) => {
             {chatRoom.userInfo?.name?.charAt(0) || "?"}
           </div>
         )}
-        {(chatRoom.hasUnreadMessages ||
-          ("check" in chatRoom && Boolean(chatRoom.check))) && (
+        {!chatRoom.check && (
           <span className="absolute -top-0 -right-1 h-4 w-4 rounded-full border-2 border-[var(--white)] bg-[var(--noti)]"></span>
         )}
       </div>
@@ -56,9 +54,7 @@ const ChatRoomItem: React.FC<ChatRoomItemProps> = ({ chatRoom, onClick }) => {
             {chatRoom.lastMessage}
           </span>
           <span className="ml-2 flex-shrink-0 truncate overflow-hidden text-sm text-ellipsis whitespace-nowrap text-[var(--gray-40)]">
-            {chatRoom.lastMessageTime
-              ? getTimeAgo(chatRoom.lastMessageTime)
-              : "방금 전"}
+            방금 전
           </span>
         </div>
       </div>

--- a/coffect/src/components/chat/ImageMessageBubble.tsx
+++ b/coffect/src/components/chat/ImageMessageBubble.tsx
@@ -10,41 +10,66 @@ interface ImageMessageBubbleProps {
   imageUrl: string;
   showProfile: boolean;
   profileImage?: string;
+  time?: string;
+  showTime?: boolean;
 }
+
+const timeText = "mb-1 text-[11px] text-[var(--gray-40)] whitespace-nowrap";
 
 const ImageMessageBubble: React.FC<ImageMessageBubbleProps> = ({
   mine,
   imageUrl,
   showProfile,
   profileImage,
-}) => (
-  <div
-    className={
-      mine
-        ? "flex items-end justify-end gap-2"
-        : "flex flex-row items-start gap-2"
-    }
-  >
-    {/* 상대방이 이미지를 보냈을 때 프로필과 같이 띄어지기 */}
-    {!mine && showProfile && (
-      <div className="h-8 w-8 flex-shrink-0 overflow-hidden rounded-full bg-[var(--gray-20)]">
-        {profileImage ? (
-          <img
-            src={profileImage}
-            alt="프로필"
-            className="h-full w-full object-cover"
-          />
-        ) : (
-          <div className="h-full w-full rounded-full border border-[var(--gray-10)] bg-[var(--gray-30)]" />
-        )}
+  time,
+  showTime = true,
+}) => {
+  if (mine) {
+    return (
+      <div className="flex items-end justify-end gap-2">
+        <span className={`${timeText} ${!showTime ? "invisible" : ""}`}>
+          {showTime ? time : "\u00A0"}
+        </span>
+        <img
+          src={imageUrl}
+          alt="전송된 이미지"
+          className="max-h-[160px] max-w-[160px] rounded-lg border border-[var(--gray-10)] object-cover"
+        />
       </div>
-    )}
-    <img
-      src={imageUrl}
-      alt="전송된 이미지"
-      className="max-h-[160px] max-w-[160px] rounded-lg border border-[var(--gray-10)] object-cover"
-    />
-  </div>
-);
+    );
+  }
+
+  return (
+    <div className="flex flex-row items-start gap-2">
+      {showProfile ? (
+        <div className="h-8 w-8 flex-shrink-0 overflow-hidden rounded-full bg-[var(--gray-20)]">
+          {profileImage ? (
+            <img
+              src={profileImage}
+              alt="프로필"
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="h-full w-full rounded-full border border-[var(--gray-10)] bg-[var(--gray-30)]" />
+          )}
+        </div>
+      ) : (
+        <div className="h-8 w-8 flex-shrink-0" />
+      )}
+      <div className="flex min-w-0 flex-row items-end gap-2">
+        <img
+          src={imageUrl}
+          alt="전송된 이미지"
+          className="max-h-[160px] max-w-[160px] rounded-lg border border-[var(--gray-10)] object-cover"
+        />
+        <span
+          className={`flex-shrink-0 self-end ${timeText} ${!showTime ? "invisible" : ""}`}
+        >
+          {showTime ? time : "\u00A0"}
+        </span>
+      </div>
+    </div>
+  );
+};
 
 export default ImageMessageBubble;

--- a/coffect/src/components/chat/MessageBubble.tsx
+++ b/coffect/src/components/chat/MessageBubble.tsx
@@ -58,14 +58,14 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
       ) : (
         <div className="h-8 w-8 flex-shrink-0" />
       )}
-      <div className="flex min-w-0 flex-row items-end">
+      <div className="flex min-w-0 flex-row items-end gap-2">
         <div
           className={`${otherBubble} ${text === "안녕하세요!" ? "whitespace-nowrap" : "whitespace-pre-line"}`}
         >
           {text}
         </div>
         <span
-          className={`ml-2 flex-shrink-0 self-end ${timeText} ${!showTime ? "invisible" : ""}`}
+          className={`flex-shrink-0 self-end ${timeText} ${!showTime ? "invisible" : ""}`}
         >
           {showTime ? time : "\u00A0"}
         </span>

--- a/coffect/src/hooks/chat/useChatRooms.ts
+++ b/coffect/src/hooks/chat/useChatRooms.ts
@@ -3,7 +3,7 @@
  * description : 채팅방 목록 조회, 소켓 연결 관리
  */
 
-import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { getChatRoomList } from "../../api/chat/chatRoomApi";
 import { getProfile, getProfileSearch } from "../../api/profile";
 import { getUserStringId } from "../../api/home";
@@ -149,6 +149,7 @@ export const useChatRooms = (): UseChatRoomsReturn => {
     } finally {
       setIsLoading(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // 초기 로드
@@ -159,20 +160,11 @@ export const useChatRooms = (): UseChatRoomsReturn => {
     return () => {
       isMountedRef.current = false;
     };
-  }, []); // loadChatRooms 의존성 제거
-
-  // 채팅방 목록 정렬 (최근 메시지 순)
-  const sortedChatRooms = useMemo(() => {
-    return [...chatRooms].sort((a, b) => {
-      // 시간순 정렬 (최신 메시지가 위로)
-      const timeA = new Date(a.lastMessageTime ?? 0).getTime();
-      const timeB = new Date(b.lastMessageTime ?? 0).getTime();
-      return timeB - timeA;
-    });
-  }, [chatRooms]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return {
-    chatRooms: sortedChatRooms,
+    chatRooms,
     isLoading,
     error,
     loadChatRooms,

--- a/coffect/src/types/chat/index.ts
+++ b/coffect/src/types/chat/index.ts
@@ -42,9 +42,7 @@ export interface ChatRoom {
   chatroomId: string;
   userId: number;
   lastMessage: string;
-  hasUnreadMessages: boolean;
-  lastReadMessageId?: string; // 마지막으로 읽은 메시지 ID
-  lastMessageTime?: string; // 마지막 메시지 시간 (시간순 정렬용)
+  check: boolean;
 }
 
 // 사용자 정보가 포함된 채팅방 타입


### PR DESCRIPTION
### 💡 To Reviewers

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- 상대 이미지 메세지 버블 레이아웃 깨짐 문제 해결
- 이미지 메세지 버블에도 전송 시간 표시 추가
- 메세지 목록에서의 읽음 처리 표시만 추가 (아직 실제로 읽어오지는 못함)

### 🔗 관련 이슈
- #166 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 이미지 메시지에 시간 표시가 추가되어 텍스트 메시지와 동일한 표시 규칙을 따릅니다.
- 스타일
  - 상대 메시지 말풍선과 시간 사이 간격 개선.
  - 프로필 아바타와 이미지가 더 자연스러운 원형으로 표시되도록 시각적 다듬기.
- 리팩터
  - 채팅방 목록의 마지막 메시지 시간 표시를 “방금 전”으로 단순화.
  - 안 읽은 표시 배지 노출 조건을 단순화.
  - 채팅방 목록 정렬을 제거하여 서버 순서대로 표시.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->