### PR TITLE
[Fix] 배너 저장 내용 라우팅 시에도 유지되도록 수정

### DIFF
--- a/coffect/src/main.tsx
+++ b/coffect/src/main.tsx
@@ -1,4 +1,3 @@
-// src/main.tsx
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
@@ -25,7 +24,7 @@ root.render(
     const isDev = import.meta.env.DEV;
     const swUrl = isDev ? "/dev-sw.js?dev-sw" : "/sw.js";
 
-    // 반대편 SW 정리(선택)
+    // 반대편 SW 정리
     for (const r of await navigator.serviceWorker.getRegistrations()) {
       const url = r.active?.scriptURL || "";
       if (isDev ? url.includes("/sw.js") : url.includes("/dev-sw")) {
@@ -70,7 +69,7 @@ root.render(
 
       const token = await getToken(msg, {
         vapidKey: import.meta.env.VITE_FIREBASE_VAPID_KEY,
-        serviceWorkerRegistration: reg, // ★ 이 탭의 SW와 바인딩
+        serviceWorkerRegistration: reg, // 이 탭의 SW와 바인딩
       });
       console.log("[FCM] token:", token);
     }

--- a/coffect/src/sw.ts
+++ b/coffect/src/sw.ts
@@ -35,7 +35,7 @@ initializeApp(firebaseConfig);
 const messaging = getMessaging();
 
 /* ------------------------------- Debug ---------------------------------- */
-const DEBUG = true; // 운영에서 끄고 싶으면 import.meta.env.DEV 로 변경
+const DEBUG = true;
 function debug(label: string, data?: unknown) {
   if (!DEBUG) return;
   try {


### PR DESCRIPTION
### 💡 To Reviewers
- 해당 브랜치에서 새롭게 설치한 라이브러리가 있다면 함께 명시해 주세요.
- 리뷰어가 코드를 이해하는 데 도움이 되는 정보나 참고사항이 있다면 자유롭게 작성해 주세요.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
배너 상태 저장/복구 개선
- SW에 저장된 배너 정보를 라우팅 시에도 flush 받아 표시 가능하도록 변경
- 배너 삭제 시 SW 저장분까지 동기화 삭제 처리
메시지 수신 구조 정리
- onMessageListener 제거 → SW postMessage & 전역 이벤트(coffect:fcm)로 일원화
- ACCEPT_RESULT 알림 분기 처리 로직 보강

### 🤔 추후 작업 예정
- 추가 구현이 필요한 부분이나 다음 작업 계획을 작성해 주세요.

### 📸 작업 결과 (스크린샷)
- 작업 결과를 보여주는 스크린샷을 첨부해 주세요.

### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: closed #182


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 푸시 알림 동작 개선: 포그라운드/백그라운드 처리와 클릭 시 포커스/새 창 열기 동작 안정화, 다중 탭 동기화 강화.
- UI/Style
  - 이미지 메시지에도 시간 표시가 추가되었습니다.
  - 커뮤니티 피드/작성 화면 아이콘을 커스텀 자산으로 교체해 시각 일관성을 향상했습니다.
  - 필터 모달 버튼 및 아바타/타임스탬프 간격 등 스타일을 다듬었습니다.
  - 채팅방 목록의 마지막 메시지 시간은 “방금 전”으로 표시되며, 읽음 배지 표기가 조정되었습니다.
- Chores
  - 빌드 구성에 SVG를 리액트 컴포넌트로 임포트할 수 있는 기능을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->