### PR TITLE
feat: sw.ts에 workbox 관련 경고 제한 라이브러리 추가

### DIFF
--- a/coffect/package.json
+++ b/coffect/package.json
@@ -40,6 +40,8 @@
     "swiper": "^11.2.10",
     "tailwindcss": "^4.1.11",
     "workbox-precaching": "^7.3.0",
+    "workbox-routing": "^7.3.0",
+    "workbox-strategies": "^7.3.0",
     "zustand": "^5.0.7"
   },
   "devDependencies": {

--- a/coffect/pnpm-lock.yaml
+++ b/coffect/pnpm-lock.yaml
@@ -59,6 +59,12 @@ importers:
       workbox-precaching:
         specifier: ^7.3.0
         version: 7.3.0
+      workbox-routing:
+        specifier: ^7.3.0
+        version: 7.3.0
+      workbox-strategies:
+        specifier: ^7.3.0
+        version: 7.3.0
       zustand:
         specifier: ^5.0.7
         version: 5.0.7(@types/react@19.1.10)(react@19.1.1)

--- a/coffect/src/sw.ts
+++ b/coffect/src/sw.ts
@@ -17,6 +17,8 @@ declare const self: ServiceWorkerGlobalScope & {
 import { precacheAndRoute } from "workbox-precaching";
 import { initializeApp } from "firebase/app";
 import { getMessaging, onBackgroundMessage } from "firebase/messaging/sw";
+import { registerRoute } from "workbox-routing";
+import { StaleWhileRevalidate } from "workbox-strategies";
 
 // ===== Workbox =====
 precacheAndRoute(self.__WB_MANIFEST);
@@ -35,7 +37,7 @@ initializeApp(firebaseConfig);
 const messaging = getMessaging();
 
 /* ------------------------------- Debug ---------------------------------- */
-const DEBUG = false; // FCM 개발 시에만 true로 설정
+const DEBUG = true;
 function debug(label: string, data?: unknown) {
   if (!DEBUG) return;
   try {
@@ -358,3 +360,14 @@ self.addEventListener("notificationclick", (event: NotificationEvent) => {
     })(),
   );
 });
+
+registerRoute(({ request, url }) => {
+  if (url.pathname.endsWith(".ts") || url.pathname.endsWith(".tsx")) {
+    return false;
+  }
+  return (
+    request.destination === "script" ||
+    request.destination === "style" ||
+    request.destination === "document"
+  );
+}, new StaleWhileRevalidate());


### PR DESCRIPTION
### 💡 To Reviewers
- pnpm add workbox-routing workbox-strategies

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- sw.ts에 workbox 관련 경고 제한 라이브러리 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 서비스 워커에 라우트 기반 캐싱을 적용하여 스크립트, 스타일, 문서를 stale-while-revalidate로 처리합니다. 초기 로딩 속도와 재방문 응답성이 향상됩니다.
  * 디버그 로깅 활성화로 서비스 워커 동작 가시성이 개선됩니다. (일반 사용자에게는 기능 동일)
* 작업
  * 캐싱 전략 강화를 위해 workbox-routing, workbox-strategies 의존성을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->