### PR TITLE
[Fix] 댓글 2줄 이상 작성 시에 이미지 깨지는 문제 수정

### DIFF
--- a/coffect/src/components/communityComponents/comment/CommentItem.tsx
+++ b/coffect/src/components/communityComponents/comment/CommentItem.tsx
@@ -31,7 +31,7 @@ const CommentItem = ({ comment }: CommentItemProps) => {
       <img
         src={comment.user.profileImage || "https://via.placeholder.com/40"}
         alt={comment.user.name}
-        className="mt-0.5 h-10 w-10 rounded-full object-cover"
+        className="h-10 w-10 flex-shrink-0 rounded-full object-cover"
       />
       <div className="flex min-w-0 flex-grow flex-col">
         <div className="flex items-center gap-1.5">


### PR DESCRIPTION
### 💡 To Reviewers
- 해당 브랜치에서 새롭게 설치한 라이브러리가 있다면 함께 명시해 주세요.
없습니다.

- 리뷰어가 코드를 이해하는 데 도움이 되는 정보나 참고사항이 있다면 자유롭게 작성해 주세요.
문제 : 부모 flex 컨테이너의 레이아웃 영향으로 인해 img 도 영향을 받고 있었습니다.
따라서 : flex-shrink-0을 추가했슴다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- 댓글 2줄 이상 작성 시 프로필 img 깨지는 버그 수정
<img width="825" height="429" alt="image" src="https://github.com/user-attachments/assets/334db363-e474-4fe5-8916-e7a657d562d2" />


### 🤔 추후 작업 예정
- 추가 구현이 필요한 부분이나 다음 작업 계획을 작성해 주세요.
#211 수정

### 📸 작업 결과 (스크린샷)
- 작업 결과를 보여주는 스크린샷을 첨부해 주세요.
<img width="406" height="452" alt="image" src="https://github.com/user-attachments/assets/70212570-2cf6-405e-8c65-2c2661e8f396" />


### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: closed #214 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 댓글 목록에서 프로필 이미지의 수직 정렬이 어긋나 보이던 현상을 개선하여 텍스트와 자연스럽게 정렬되도록 수정했습니다. 전반적인 가독성과 시각적 일관성이 향상되었습니다.
  - 프로필 이미지가 리스트 레이아웃에서 축소되거나 찌그러질 수 있던 문제를 방지하여 항상 동일한 크기와 비율을 유지합니다. 스크롤 시 레이아웃 흔들림도 줄었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->